### PR TITLE
Namespaced sugar require to ronad/sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ talk https://codon.com/refactoring-ruby-with-monads
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'ronad', require: 'sugar'
+gem 'ronad', require: 'ronad/sugar'
 ```
 
 Alernatively without sugar

--- a/lib/ronad/sugar.rb
+++ b/lib/ronad/sugar.rb
@@ -1,0 +1,10 @@
+require 'ronad/maybe'
+require 'ronad/just'
+require 'ronad/default'
+require 'ronad/eventually'
+
+def Maybe(value) ; Ronad::Maybe.new(value) end
+def Just(value); Ronad::Just.new(value) end
+def Default(fallback, value) ; Ronad::Default.new(fallback, value) end
+def Eventually(&b); Ronad::Eventually.new(b) end
+

--- a/lib/ronad/version.rb
+++ b/lib/ronad/version.rb
@@ -1,3 +1,3 @@
 module Ronad
-  VERSION = '0.5.0'
+  VERSION = '0.6.1'
 end

--- a/lib/sugar.rb
+++ b/lib/sugar.rb
@@ -1,10 +1,2 @@
-require 'ronad/maybe'
-require 'ronad/just'
-require 'ronad/default'
-require 'ronad/eventually'
-
-def Maybe(value) ; Ronad::Maybe.new(value) end
-def Just(value); Ronad::Just.new(value) end
-def Default(fallback, value) ; Ronad::Default.new(fallback, value) end
-def Eventually(&b); Ronad::Eventually.new(b) end
-
+warn "[DEPRECATION] Requiring 'sugar' is depcreated. Require 'ronad/sugar' instead."
+require 'ronad/sugar'


### PR DESCRIPTION
If using bundler the require option should change to:

    gem 'ronad', require: 'ronad/sugar'

Require just 'ronad' has been deprecated.